### PR TITLE
feat: handle an edge case related to `{dirname}`

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -293,7 +293,8 @@ function! g:projectionist_transformations.snakecase(input, o) abort
 endfunction
 
 function! g:projectionist_transformations.dirname(input, o) abort
-  return substitute(a:input, '.[^'.projectionist#slash().'/]*$', '', '')
+  let dir = substitute(a:input, '.[^'.projectionist#slash().'/]*$', '', '')
+  return (dir == "") ? "." : dir
 endfunction
 
 function! g:projectionist_transformations.basename(input, o) abort
@@ -851,7 +852,7 @@ function! s:edit_command(mods, edit, count, ...) abort
       let i = 0
       for [alt, _] in alternates
         let i += 1
-        let relative = fnamemodify(alt, ":~:.")
+        let relative = substitute(fnamemodify(alt, ":~:."), "^\./", "", "")
         call add(choices, i.' '.relative)
       endfor
       let i = inputlist(choices)


### PR DESCRIPTION
Seeing as GitHub doesn't have stacked PRs, creating this one as a temporary placeholder. If:

- https://github.com/tpope/vim-projectionist/pull/190

gets merged upstream, will create a new PR over there containing this commit too.

---

If you have an alternate mapping from, say:

    "*.ts"

to:

    "{dirname}/__tests__/{basename}-test.ts"

Then the "Create alternate file" menu will show something like this:

    Create alternate file?
    1 ...
    2 ...
    3 /__tests__/example.test.ts
    4 ...
    Type number and <Enter> or click with the mouse (q or empty cancels):

After this commit, it instead shows this:

    Create alternate file?
    1 ...
    2 ...
    3 __tests__/example.test.ts
    4 ...
    Type number and <Enter> or click with the mouse (q or empty cancels):

What was going on here? Well, a pattern like `"*.ts"` matching a file `"example.ts"` was getting decomposed as follows:

- `"{dirname}"` was expanding to an empty string.
- `"{basename}"` was `"example.ts"`

When we concatenate these together with `"/__tests__/"` in between, we got `"/__tests__/example.test.ts"`, which looks like an absolute path but is not supposed to be one.

The fix comes in two parts:

1. Instead of expanding `"{dirname}"` to `""`, we expand it to `"."` to prevent it from being empty. This in itself is enough to make the "Create alternate file" display a relative path if we have an expansion like `"{dirname}/{basename}.test.ts"` (although you could write this as `"{}.test.ts"` and avoid the problem).
2. If our alternate starts with `"./"`, we strip it off. This is what handles the specific example mentioned above. `"./__tests__/foo.test.ts"` becomes `"__tests__/foo.test.ts"`.
